### PR TITLE
Fix attribute typo in entities

### DIFF
--- a/backend/atestadoToText.py
+++ b/backend/atestadoToText.py
@@ -31,8 +31,8 @@ def generar_descripcion(atestado: Atestado) -> str:
             partes = [a.id]
             if a.edad:
                 partes.append(f"{a.edad} años")
-            if a.organicacion_criminal:
-                partes.append(f"miembro de la organización '{a.organicacion_criminal}'")
+            if a.organizacion_criminal:
+                partes.append(f"miembro de la organización '{a.organizacion_criminal}'")
             if a.antecedentes > 0:
                 partes.append(f"con {a.antecedentes} antecedentes")
             acusados.append(" ".join(partes))

--- a/backend/decisionTree.py
+++ b/backend/decisionTree.py
@@ -234,7 +234,7 @@ def caracteristicasAcusado(atestado_llm: AtestadoLLM, atestado: entities.Atestad
         if orgCriminal.lower() == 'sí':
             acusado.caracteristicas_acusado.append("Organización Criminal")
             nombreOrganizacion = atestado_llm.preguntar(questions.NOMBRE_ORGANIZACION.format(acusado=acusado.id))
-            acusado.organicacion_criminal = nombreOrganizacion
+            acusado.organizacion_criminal = nombreOrganizacion
         
         antecedentes = atestado_llm.preguntar(questions.ANTECEDENTES.format(acusado=acusado.id))
         if antecedentes.lower() == 'sí':

--- a/backend/entities.py
+++ b/backend/entities.py
@@ -13,7 +13,7 @@ class Bien(BaseModel):
 class Acusado(BaseModel):
     id: str
     edad: int = 0
-    organicacion_criminal: str = ""
+    organizacion_criminal: str = ""
     antecedentes: int = 0
     caracteristicas_acusado: List[str] = []
 

--- a/backend/rdfFile.py
+++ b/backend/rdfFile.py
@@ -95,10 +95,10 @@ def nuevoAcusado(g, acusado: Acusado, atestado: Atestado, atestado_uri: URIRef):
     acusado_uri = URIRef(f"{DELPATRIMONIO}_{uriSegura(atestado.atestado_id)}_{uriSegura(acusado.id)}")
     g.add((acusado_uri, RDF.type, DELPATRIMONIO.Accused))
 
-    if acusado.organicacion_criminal != "":
-        criminal_org_uri = URIRef(f"{DELPATRIMONIO}_{uriSegura(atestado.atestado_id)}_{uriSegura(acusado.organicacion_criminal)}")
+    if acusado.organizacion_criminal != "":
+        criminal_org_uri = URIRef(f"{DELPATRIMONIO}_{uriSegura(atestado.atestado_id)}_{uriSegura(acusado.organizacion_criminal)}")
         g.add((criminal_org_uri, RDF.type, DELPATRIMONIO.CriminalOrganization))
-        g.add((criminal_org_uri, DELPATRIMONIO.Name, Literal(acusado.organicacion_criminal)))
+        g.add((criminal_org_uri, DELPATRIMONIO.Name, Literal(acusado.organizacion_criminal)))
         g.add((acusado_uri, DELPATRIMONIO.belongsToCriminalOrganization, criminal_org_uri))
 
     # Verificar antecedentes y características del acusado


### PR DESCRIPTION
## Summary
- fix spelling of `organizacion_criminal` field
- update references in description generator
- update decision tree and RDF creator

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684961862080832f82c9921f0519a5aa