### PR TITLE
Add documentation strings

### DIFF
--- a/backend/atestadoToText.py
+++ b/backend/atestadoToText.py
@@ -3,6 +3,7 @@ from entities import Atestado
 
 # Función para generar una descripción textual de un atestado
 def generar_descripcion(atestado: Atestado) -> str:
+    """Devuelve un resumen en lenguaje natural del ``Atestado`` proporcionado."""
     descripcion = []
 
     descripcion.append(f"El atestado {atestado.atestado_id} documenta un presunto delito contra la propiedad.")

--- a/backend/entities.py
+++ b/backend/entities.py
@@ -35,15 +35,19 @@ class Atestado(BaseModel):
     factores_mitigantes: List[str] = []
 
 def initBienes(nombres: List[str]) -> List[Bien]:
+    """Crea objetos ``Bien`` a partir de una lista de nombres."""
     return [Bien(nombre=nombre) for nombre in nombres]
 
 def initAcusados(ids: List[str]) -> List[Acusado]:
+    """Inicializa instancias de ``Acusado`` para los identificadores dados."""
     return [Acusado(id=id) for id in ids]
 
 def initVictimas(ids: List[str]) -> List[Victima]:
+    """Devuelve una lista de ``Victima`` basándose en sus identificadores."""
     return [Victima(id=id) for id in ids]
 
 def initAtestado(atestado_id: str, bienes: List[Bien], victimas: List[Victima], autores: List[Acusado]) -> Atestado:
+    """Construye un objeto ``Atestado`` con sus elementos principales."""
     return Atestado(
         atestado_id=atestado_id,
         bienes_robados=bienes,
@@ -52,5 +56,6 @@ def initAtestado(atestado_id: str, bienes: List[Bien], victimas: List[Victima], 
     )
 
 def filtrar_bienes(lista):
+    """Elimina nombres que hagan referencia a dinero de una lista de bienes."""
     patron = re.compile(r'\b(euro\w*|billete\w*|moneda\w*)\b', re.IGNORECASE)
     return [item for item in lista if not patron.search(item)]

--- a/backend/rdfFile.py
+++ b/backend/rdfFile.py
@@ -10,6 +10,7 @@ DELPATRIMONIO = Namespace("http://www.semanticweb.org/fjnavarrete/ontologies/202
 
 ## ---- Función para iniciar un grafo RDF -----
 def iniciar_grafo():
+    """Crea un grafo RDF inicializado con los prefijos de la ontología."""
     g = rdflib.Graph()
     g.bind("delpatrimonio", DELPATRIMONIO)
     g.bind("owl", OWL)
@@ -51,11 +52,13 @@ def iniciar_grafo():
     return g
 
 def uriSegura(text: str) -> str:
+    """Devuelve una representación segura para usar en URIs."""
     text = text.strip().replace("/", "_")
     return text.strip().replace(" ", "_")
 
 ## ---- Añadir un nuevo bien -----
 def nuevoBien(g, bien: Bien, atestado: Atestado, atestado_uri: URIRef, primerBien: bool):
+    """Añade un bien sustraído al grafo RDF."""
     bien_uri = URIRef(f"{DELPATRIMONIO}_{uriSegura(atestado.atestado_id)}_{uriSegura(bien.nombre)}")
     g.add((bien_uri, RDF.type, DELPATRIMONIO.StolenGoods))
     g.add((atestado_uri, DELPATRIMONIO.stolenthing, bien_uri))
@@ -82,6 +85,7 @@ def nuevoBien(g, bien: Bien, atestado: Atestado, atestado_uri: URIRef, primerBie
 
 ## ---- Añadir nueva víctima -----
 def nuevaVictima(g, victima: Victima, atestado: Atestado):
+    """Registra una víctima en el grafo."""
     # Crear la URI de la víctima
     victima_uri = URIRef(f"{DELPATRIMONIO}_{uriSegura(atestado.atestado_id)}_{uriSegura(victima.id)}")
     
@@ -92,6 +96,7 @@ def nuevaVictima(g, victima: Victima, atestado: Atestado):
 
 ## ---- Añadir nuevo acusado (autor o cómplice) -----
 def nuevoAcusado(g, acusado: Acusado, atestado: Atestado, atestado_uri: URIRef):
+    """Añade al grafo la información de un acusado o cómplice."""
     acusado_uri = URIRef(f"{DELPATRIMONIO}_{uriSegura(atestado.atestado_id)}_{uriSegura(acusado.id)}")
     g.add((acusado_uri, RDF.type, DELPATRIMONIO.Accused))
 
@@ -155,6 +160,7 @@ def nuevoAcusado(g, acusado: Acusado, atestado: Atestado, atestado_uri: URIRef):
 
 ## ---- Añadir el atestado completo -----
 def nuevoAtestadoRobo(atestado: Atestado):
+    """Construye el RDF de un atestado clasificado como robo."""
     g = iniciar_grafo()
 
     # Crear URI único para el atestado
@@ -213,6 +219,9 @@ def nuevoAtestadoRobo(atestado: Atestado):
 ## ---- Añadir el atestado completo -----
 def nuevoAtestadoHurto(atestado: Atestado):
 
+    """Construye el RDF de un atestado de hurto, creando restricciones
+    cuando no hay características del delito."""
+
     g = iniciar_grafo()
 
     atestado_uri = URIRef(f"{DELPATRIMONIO}{uriSegura(atestado.atestado_id)}")
@@ -269,6 +278,7 @@ def nuevoAtestadoHurto(atestado: Atestado):
     return g, nombre_archivo
 
 def crear_rdf(atestado: Atestado):
+    """Crea el archivo RDF correspondiente a un ``Atestado``."""
     if len(atestado.caracteristicas_del_delito) == 0 or atestado.caracteristicas_del_delito[0] == "Neutralización, eliminación o inutilización de alarmas o dispositivos de seguridad": 
         grafo, nombre_archivo = nuevoAtestadoHurto(atestado)
     else:
@@ -285,6 +295,7 @@ def crear_rdf(atestado: Atestado):
     return f"{nombre_archivo}.rdf"
 
 def filtrar_grafo(rdf_text: str, formato="xml", namespace_base="http://www.semanticweb.org/fjnavarrete/ontologies/2022/0/delito_contra_patrimonio#") -> Graph:
+    """Elimina nodos externos al informe manteniendo solo información relevante."""
     g_original = Graph()
     g_original.parse(data=rdf_text, format=formato)
 

--- a/backend/reasonerFromFile.py
+++ b/backend/reasonerFromFile.py
@@ -11,6 +11,7 @@ from articles import ARTICULOS_EXPLICACION
 ONTOLOGY = "SCPO_Extended_Ontology_V01R08_AT08Q.owl"
 
 def extract_local_name(iri):
+    """Return the local fragment of an IRI."""
     if '#' in iri:
         return iri.split('#')[-1]
     else:
@@ -19,6 +20,7 @@ def extract_local_name(iri):
 
 
 def import_rdf_individuals(rdf_graph, onto):
+    """Importa individuos y relaciones de un grafo RDF a una ontología."""
 
     existing_individuals = {ind.name for ind in onto.individuals()}
     individual_map = {}  
@@ -115,6 +117,7 @@ def import_rdf_individuals(rdf_graph, onto):
 
 
 def aplicar_not_sobre_hasOffenceCharacteristic_si_es_nothing(rdf_graph, onto):
+    """Añade inferencias negativas cuando la propiedad está restringida a Nothing."""
 
     for subj in rdf_graph.subjects(RDF.type, None):
         # Para cada tipo que sea un BNode (clase anónima)
@@ -148,6 +151,7 @@ def aplicar_not_sobre_hasOffenceCharacteristic_si_es_nothing(rdf_graph, onto):
 
 
 def reasoner(ruta_grafo):
+    """Carga un RDF, importa sus individuos y ejecuta el razonador Pellet."""
     print(f"📄 Cargando archivo RDF desde: {ruta_grafo}")
 
     onto = get_ontology(ONTOLOGY).load(reload=True)
@@ -184,6 +188,7 @@ def reasoner(ruta_grafo):
     return sorted(clases_inferidas)
 
 def construir_articulos_inferidos(lista_clases: list[str]) -> list[str]:
+    """Convierte las clases inferidas en referencias legislativas."""
     res = [ARTICULOS_EXPLICACION[c] for c in lista_clases if c in ARTICULOS_EXPLICACION]
     print(res)
     return res


### PR DESCRIPTION
## Summary
- document key API functions
- add docstrings across the decision tree workflow
- explain helpers in RDF generation, text conversion and reasoner modules
- clarify entity factory helpers

## Testing
- `python -m py_compile backend/api.py backend/decisionTree.py backend/rdfFile.py backend/atestadoToText.py backend/entities.py backend/reasonerFromFile.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684966318260832f91a1bcb3661c7a1d