### PR TITLE
Add README files for project folders

### DIFF
--- a/OpcionesFallidas/README.md
+++ b/OpcionesFallidas/README.md
@@ -1,0 +1,8 @@
+# OpcionesFallidas
+
+Contiene diversos scripts de pruebas y versiones previas para la extracción y análisis de ontologías. No forman parte del flujo principal pero se conservan como referencia.
+
+Archivos relevantes:
+- `main.py` – script de entrada que invoca distintas pruebas.
+- `ontologyAnalizer.py` y `ontologyExtract*.py` – utilidades para explorar ontologías.
+- `dataExtractComplete.py` – intentos de extracción completa de datos.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # VeredictAI
-Repositorio para desarrollo de una herramienta de asistencia jurídica
+
+Repositorio para el desarrollo de una herramienta de asistencia jurídica.
+
+## Estructura general
+
+- **backend/** – API en Python y utilidades para procesar atestados, generar RDF e inferir artículos.
+- **frontend/** – Aplicación web en React que interactúa con la API.
+- **OpcionesFallidas/** – Scripts experimentales usados en etapas previas del proyecto.
+
+Cada carpeta cuenta con un README adicional con información detallada.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,17 @@
+# Backend
+
+Este directorio contiene el servicio de API y las utilidades de procesamiento semántico.
+
+## Archivos destacados
+
+- `api.py` – API construida con FastAPI para procesar atestados, generar RDF y realizar inferencias.
+- `decisionTree.py` – Árbol de decisión que utiliza un modelo LLM para clasificar los delitos.
+- `entities.py` – Modelos de datos (bienes, víctimas, acusados, atestados...).
+- `atestadoToText.py` – Genera descripciones en lenguaje natural a partir de un `Atestado`.
+- `rdfFile.py` – Crea grafos RDF según la ontología definida y permite filtrarlos.
+- `documents.py` – Funciones auxiliares para leer archivos PDF y DOCX.
+- `reasonerFromFile.py` – Carga un RDF en la ontología `SCPO_Extended_Ontology` y ejecuta el razonador Pellet.
+- `SCPO_Extended_Ontology_V01R08_AT08Q.owl` y `catalog-v001.xml` – Ontología utilizada y su catálogo.
+- `Dockerfile`, `render-build.sh` y `vercel.json` – Archivos para despliegue.
+- `requirements.txt` – Dependencias de Python.
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,13 @@
-# React + Vite
+# Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Aplicación web desarrollada con React y Vite. Proporciona la interfaz de usuario para subir atestados, visualizar grafos RDF e inferir artículos legales.
 
-Currently, two official plugins are available:
+## Contenido
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- `index.html` – documento HTML principal servido por Vite.
+- `src/` – código fuente de la aplicación React.
+- `public/` – recursos estáticos copiados tal cual al directorio de salida.
+- `package.json` y `package-lock.json` – dependencias y scripts de desarrollo.
+- `vite.config.js` y `vercel.json` – configuración de Vite y despliegue.
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Consulta los README de los subdirectorios para más detalles.

--- a/frontend/public/README.md
+++ b/frontend/public/README.md
@@ -1,0 +1,4 @@
+# Public
+
+Archivos estáticos que se copian sin cambios en la compilación de Vite.
+Actualmente solo contiene el icono `vite.svg`, usado por la plantilla.

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -1,0 +1,8 @@
+# src
+
+Código fuente principal de la aplicación React.
+
+- `App.jsx` y `main.jsx` – definen la estructura y arrancan la aplicación.
+- `assets/` – imágenes y recursos estáticos utilizados por los componentes.
+- `components/` – componentes reutilizables como la barra de navegación o el pie de página.
+- `pages/` – vistas de la aplicación (home, procesamiento de atestados y analizador RDF).

--- a/frontend/src/assets/README.md
+++ b/frontend/src/assets/README.md
@@ -1,0 +1,10 @@
+# Assets
+
+Imágenes y recursos estáticos utilizados por el frontend.
+
+Incluye iconos y fondos como:
+- `docs.png`
+- `fondo.jpg`
+- `logo.png`
+- `noArchivo.png`
+- `react.svg`

--- a/frontend/src/components/README.md
+++ b/frontend/src/components/README.md
@@ -1,0 +1,8 @@
+# Components
+
+Componentes reutilizables del frontend.
+
+- `Navbar.jsx` y `Navbar.css` – barra de navegación principal.
+- `Footer.jsx` y `Footer.css` – pie de página.
+- `context.jsx` – contexto React para compartir el resultado de procesamiento.
+- `ui/` – componentes de interfaz genéricos, como `Loading.jsx`.

--- a/frontend/src/components/ui/README.md
+++ b/frontend/src/components/ui/README.md
@@ -1,0 +1,5 @@
+# UI Components
+
+Pequeños componentes de interfaz utilizados en varias pantallas.
+
+Actualmente sólo contiene `Loading.jsx`, un indicador de carga reutilizable.

--- a/frontend/src/pages/README.md
+++ b/frontend/src/pages/README.md
@@ -1,0 +1,7 @@
+# Pages
+
+Contiene las vistas principales de la aplicación.
+
+- `home/` – página de bienvenida y enlaces a las funciones.
+- `atestados/` – formulario para procesar atestados en PDF o DOCX con la API.
+- `analizador/` – carga de archivos RDF para visualizar el grafo e inferir artículos.

--- a/frontend/src/pages/analizador/README.md
+++ b/frontend/src/pages/analizador/README.md
@@ -1,0 +1,3 @@
+# Analizador
+
+Interfaz para subir un archivo RDF, visualizar el grafo generado y obtener artículos legales inferidos por la API.

--- a/frontend/src/pages/atestados/README.md
+++ b/frontend/src/pages/atestados/README.md
@@ -1,0 +1,3 @@
+# Atestados
+
+Permite cargar atestados en formato PDF o DOCX. Tras procesarlos mediante la API se muestra una descripción y se puede descargar el grafo RDF resultante.

--- a/frontend/src/pages/home/README.md
+++ b/frontend/src/pages/home/README.md
@@ -1,0 +1,3 @@
+# Home
+
+Página inicial de la aplicación. Muestra una breve descripción del proyecto y enlaces rápidos a las secciones de procesamiento de atestados y análisis de RDF.


### PR DESCRIPTION
## Summary
- describe repository structure in root README
- document backend folder
- update frontend README and add READMEs for subfolders
- add README for experimental scripts under `OpcionesFallidas`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496ca1acf8832fb6693e0d22cdfc79