### PR TITLE
Add hamburger navbar for mobile

### DIFF
--- a/frontend/src/components/Navbar.css
+++ b/frontend/src/components/Navbar.css
@@ -46,6 +46,15 @@
     padding: 0;
     flex-wrap: wrap;
   }
+
+  .navbar-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.5rem;
+    cursor: pointer;
+  }
   
   .navbar-menu li a {
     color: white;
@@ -74,26 +83,48 @@
   
   @media (max-width: 768px) {
     .navbar-container {
-      flex-direction: column;
-      align-items: flex-start;
+      flex-direction: row;
     }
-  
+
+    .navbar-toggle {
+      display: block;
+    }
+
     .navbar-menu {
+      position: fixed;
+      top: 0;
+      right: -220px;
+      bottom: 0;
       flex-direction: column;
-      align-items: flex-start;
+      align-items: stretch;
       gap: 1rem;
-      margin-top: 1rem;
-      width: 100%;
+      margin: 0;
+      padding: 2rem 1rem;
+      background-color: #656667;
+      width: 200px;
+      transition: right 0.3s ease;
     }
-  
+
+    .navbar-menu.open {
+      right: 0;
+    }
+
     .navbar-menu li a {
+      display: block;
+      background-color: #575859;
+      padding: 0.75rem 1rem;
+      border-radius: 6px;
       font-size: 1rem;
     }
-  
+
+    .navbar-menu li a:hover {
+      background-color: #727374;
+    }
+
     .navbar-title {
       font-size: 1.25rem;
     }
-  
+
     .navbar-logo {
       width: 40px;
       height: 40px;
@@ -109,4 +140,3 @@
       gap: 0.5rem;
     }
   }
-  

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,8 +1,11 @@
 import './Navbar.css';
 import logo from '../assets/logo.png';
 import { NavLink, Link } from 'react-router-dom';
+import { useState } from 'react';
+import { FiMenu, FiX } from 'react-icons/fi';
 
 export default function Navbar() {
+  const [open, setOpen] = useState(false);
   return (
     <nav className="navbar">
       <div className="navbar-container">
@@ -10,7 +13,10 @@ export default function Navbar() {
           <img src={logo} alt="Logo" className="navbar-logo" />
           <h2 className="navbar-title">VeredictAI</h2>
         </Link>
-        <ul className="navbar-menu">
+        <button className="navbar-toggle" onClick={() => setOpen(!open)}>
+          {open ? <FiX /> : <FiMenu />}
+        </button>
+        <ul className={`navbar-menu ${open ? 'open' : ''}`}>
           <li>
             <NavLink
               to="/atestados"


### PR DESCRIPTION
## Summary
- enable hamburger menu using `react-icons`
- style Navbar for a slide-out mobile menu

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68497251aaa4832f9ce58f6299f9f199