### PR TITLE
Add keyboard focus styles

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -60,6 +60,11 @@ main {
   background-color: #12569d;
 }
 
+.file-label:focus {
+  outline: 2px solid #12569d;
+  outline-offset: 2px;
+}
+
 .file-preview {
   margin: 1rem 0;
   font-style: italic;
@@ -72,6 +77,11 @@ main {
   cursor: pointer;
   border: none;
   margin-right: 1rem;
+}
+
+.btn:focus {
+  outline: 2px solid #1976d2;
+  outline-offset: 2px;
 }
 
 .btn.primary {

--- a/frontend/src/components/Navbar.css
+++ b/frontend/src/components/Navbar.css
@@ -55,6 +55,11 @@
     position: relative;
     font-size: 1rem;
   }
+
+  .navbar-menu li a:focus {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+  }
   
   .navbar-menu li a.active::after {
     content: "";

--- a/frontend/src/pages/analizador/Analizador.css
+++ b/frontend/src/pages/analizador/Analizador.css
@@ -34,6 +34,11 @@
     background-color: #1976d2;
     color: white;
   }
+
+  .archivo-btn:focus {
+    outline: 2px solid #1976d2;
+    outline-offset: 2px;
+  }
   
   .archivo-btn:hover {
     background-color: #12569d;
@@ -43,6 +48,11 @@
     background-color: #388e3c;
     color: white;
   }
+
+  .analizar-btn:focus {
+    outline: 2px solid #388e3c;
+    outline-offset: 2px;
+  }
   
   .analizar-btn:hover {
     background-color: #2e7d32;
@@ -50,6 +60,11 @@
   .reiniciar-btn {
     background-color: #757575;
     color: white;
+  }
+
+  .reiniciar-btn:focus {
+    outline: 2px solid #757575;
+    outline-offset: 2px;
   }
   
   .reiniciar-btn:hover {
@@ -210,6 +225,11 @@
     color: white;
     border-radius: 6px;
     cursor: pointer;
+  }
+
+  .zoom-control button:focus {
+    outline: 2px solid #1976d2;
+    outline-offset: 2px;
   }
   
   .zoom-control button:hover {

--- a/frontend/src/pages/atestados/Atestados.css
+++ b/frontend/src/pages/atestados/Atestados.css
@@ -111,6 +111,11 @@
     display: inline-block;
     margin-right: 0.5rem;
   }
+
+  .archivo-btn:focus {
+    outline: 2px solid #1976d2;
+    outline-offset: 2px;
+  }
   
   .eliminar-btn {
     background: #d32f2f;
@@ -120,6 +125,11 @@
     cursor: pointer;
     border: none;
     font-size: 0.9rem;
+  }
+
+  .eliminar-btn:focus {
+    outline: 2px solid #d32f2f;
+    outline-offset: 2px;
   }
   
   .procesar-btn {
@@ -132,6 +142,11 @@
     cursor: pointer;
     font-weight: bold;
   }
+
+  .procesar-btn:focus {
+    outline: 2px solid #388e3c;
+    outline-offset: 2px;
+  }
   
   .descargar-btn {
     margin-top: 1rem;
@@ -142,6 +157,11 @@
     border-radius: 6px;
     cursor: pointer;
     font-weight: bold;
+  }
+
+  .descargar-btn:focus {
+    outline: 2px solid #ffa000;
+    outline-offset: 2px;
   }
   
   .resultado h3 {

--- a/frontend/src/pages/home/Home.css
+++ b/frontend/src/pages/home/Home.css
@@ -58,6 +58,11 @@
     font-weight: bold;
     transition: all 0.3s ease;
   }
+
+  .home-btn:focus {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+  }
   
   .home-btn:hover {
     background-color: #656667;


### PR DESCRIPTION
## Summary
- add focus outline for upload button, general `.btn` class
- add focus style for navbar links
- add focus style for home buttons
- add focus style for analyzer page buttons
- add focus style for statement processing buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684974996bfc832fbdf60c185c8d165a