### PR TITLE
Improve screen reader announcements

### DIFF
--- a/frontend/src/pages/analizador/Analizador.jsx
+++ b/frontend/src/pages/analizador/Analizador.jsx
@@ -140,7 +140,7 @@ export default function Analizador() {
         </div>
       )}
 
-      <div className="resultado">
+      <div className="resultado" aria-live="polite">
         <h3>Artículos Inferidos:</h3>
         {articulos.length > 0 ? (
           <ul>
@@ -155,8 +155,8 @@ export default function Analizador() {
       </div>
 
       {popupTexto && (
-        <div className="popup-overlay">
-          <div className="popup-loader">
+        <div className="popup-overlay" role="status" aria-live="polite">
+          <div className="popup-loader" aria-busy="true">
             <div className="spinner" />
             <p>{popupTexto}</p>
           </div>

--- a/frontend/src/pages/atestados/Atestados.jsx
+++ b/frontend/src/pages/atestados/Atestados.jsx
@@ -127,7 +127,7 @@ export default function Atestados() {
           </button>
         </div>
 
-        <div className="resultado">
+        <div className="resultado" aria-live="polite">
           <h3>Resultado:</h3>
           {resultado ? (
             <>
@@ -158,8 +158,8 @@ export default function Atestados() {
       </div>
 
       {popup && (
-        <div className="popup-overlay">
-          <div className="popup-loader">
+        <div className="popup-overlay" role="status" aria-live="polite">
+          <div className="popup-loader" aria-busy="true">
             <div className="spinner" />
             <p>Procesando documento...</p>
           </div>


### PR DESCRIPTION
## Summary
- announce updates in result containers with `aria-live="polite"`
- mark processing popups with `role="status"` and `aria-busy="true"`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849749ab5e4832f96d56d34085f8e0f