### PR TITLE
Implement accessible popup overlays

### DIFF
--- a/frontend/src/pages/analizador/Analizador.jsx
+++ b/frontend/src/pages/analizador/Analizador.jsx
@@ -1,5 +1,5 @@
 import './Analizador.css';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import axios from 'axios';
 import { FiUpload, FiSearch, FiRotateCw } from 'react-icons/fi';
 
@@ -13,6 +13,31 @@ export default function Analizador() {
 
   const imageRef = useRef(null);
   const visualRef = useRef(null);
+  // Ref to control focus on the popup overlay
+  const overlayRef = useRef(null);
+
+  // When the popup is visible, focus it and trap keyboard navigation.
+  useEffect(() => {
+    if (!popupTexto) return;
+
+    const overlay = overlayRef.current;
+    if (overlay) overlay.focus();
+
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        // Allow the user to cancel the loading overlay with Esc
+        e.preventDefault();
+        setPopupTexto(null);
+      }
+      if (e.key === 'Tab') {
+        // Keep focus within the overlay while it's visible
+        e.preventDefault();
+      }
+    };
+
+    overlay?.addEventListener('keydown', handleKey);
+    return () => overlay?.removeEventListener('keydown', handleKey);
+  }, [popupTexto]);
 
   const actualizarOverflow = (nuevoZoom) => {
     const zoomLimitado = Math.max(1, Math.min(1.3, nuevoZoom));
@@ -155,7 +180,14 @@ export default function Analizador() {
       </div>
 
       {popupTexto && (
-        <div className="popup-overlay">
+        /* Loading overlay. Focus is trapped and Esc closes it. */
+        <div
+          className="popup-overlay"
+          role="alertdialog"
+          aria-modal="true"
+          ref={overlayRef}
+          tabIndex="-1"
+        >
           <div className="popup-loader">
             <div className="spinner" />
             <p>{popupTexto}</p>

--- a/frontend/src/pages/atestados/Atestados.jsx
+++ b/frontend/src/pages/atestados/Atestados.jsx
@@ -1,5 +1,5 @@
 import './Atestados.css';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import axios from 'axios';
 import { FiUpload, FiTrash2, FiDownload, FiLoader } from 'react-icons/fi';
 import docs from '../../assets/docs.png';
@@ -12,6 +12,31 @@ export default function Atestados() {
   const [loading, setLoading] = useState(false);
   const [popup, setPopup] = useState(false);
   const [error, setError] = useState(null);
+  // Ref used to keep focus within the popup overlay
+  const overlayRef = useRef(null);
+
+  // When popup is visible, focus it and trap keyboard navigation
+  useEffect(() => {
+    if (!popup) return;
+
+    const overlay = overlayRef.current;
+    if (overlay) overlay.focus();
+
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        // Allow cancelling processing with Esc
+        e.preventDefault();
+        setPopup(false);
+      }
+      if (e.key === 'Tab') {
+        // Prevent focus from leaving the overlay
+        e.preventDefault();
+      }
+    };
+
+    overlay?.addEventListener('keydown', handleKey);
+    return () => overlay?.removeEventListener('keydown', handleKey);
+  }, [popup]);
 
   const handleChange = (e) => {
     const selected = e.target.files[0];
@@ -158,7 +183,14 @@ export default function Atestados() {
       </div>
 
       {popup && (
-        <div className="popup-overlay">
+        /* Processing overlay. Focus is trapped and Esc cancels. */
+        <div
+          className="popup-overlay"
+          role="alertdialog"
+          aria-modal="true"
+          ref={overlayRef}
+          tabIndex="-1"
+        >
           <div className="popup-loader">
             <div className="spinner" />
             <p>Procesando documento...</p>


### PR DESCRIPTION
## Summary
- use `alertdialog` role for loading popups
- trap keyboard focus on active overlay
- allow Escape key to close popup while processing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849749d3750832fbc97b9936a6f9cb7